### PR TITLE
Improve Job Data Structure

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 TimespanLogging = "a526e669-04d3-4846-9525-c66122c55f63"
 
 [compat]
-julia = "1.6"
+julia = "1.8"
 Dagger = "0.16"
 DaggerWebDash = "0.1"
 Graphs = "1.8"

--- a/README.md
+++ b/README.md
@@ -76,9 +76,9 @@ struct MyTarget{T} <: Waluigi.AbstracTarget{T}
     # add fields here
 end
 
-# iscompleted returns a boolean indicating whether the process should be skipped because the 
+# is_completed returns a boolean indicating whether the process should be skipped because the 
 # target is completed.
-function Waluigi.iscomplete(t::MyTarget)
+function Waluigi.is_complete(t::MyTarget)
     true
 end
 

--- a/src/Pipeline.jl
+++ b/src/Pipeline.jl
@@ -1,162 +1,31 @@
+include("PipelineInternals.jl")
 """
     run_pipeline(head_job)
 
 Given an instantiated Job, satisfied all dependencies recursively and return the result of 
 the final job. 
 """
-function run_pipeline(head_job, ignore_target=false; visualizer=false)
+function run_pipeline(@nospecialize(head_job), ignore_target=false; visualizer=false)
     if visualizer
         @info "Creating visualizer at http://localhost:8080/"
         start_viz()
     end
-    # Jobs is a dict id => AbstractJob
-    # dep_rel is a set{Tuple{job id, dep id, satisfied}
-    # job status is a dict id => bool, true means ready to run 
+
     @info "Initiating the pipeline"
-    (jobs, dependency_relations, initial_ready_jobs) = get_dependency_details(head_job)
-    @info "Collected $(length(jobs)) jobs to complete. "
-    results = Dict{UInt64, Union{Nothing, Dagger.EagerThunk}}(
-        id => nothing
-        for id in initial_ready_jobs
-    )
-    job_id = first(initial_ready_jobs)
-    completed_all_jobs = false
-    while !completed_all_jobs
-        job_deps = [
-            results[dep_pair[2]]
-            for dep_pair in dependency_relations 
-            if dep_pair[1] == job_id
-        ]
-                
-        @debug "Spawning $(jobs[job_id])"
-        results[job_id] = Dagger.@spawn (jobs[job_id])(job_id, ignore_target, job_deps...)
-        
-        # Find upstream jobs and check if completing this job makes them ready for execution
-        upstream_jobs = dependency_relations |>
-                # get jobs that depend on the completed job
-                ((dr) -> Iterators.filter((p) -> p[2] == job_id, dr)) .|>
-                # Set "satisfied" field to true
-                ((p) -> (delete!(dependency_relations, p); p)) .|>
-                ((p) -> (push!(dependency_relations, (p[1], p[2], true)); p[1])) 
-                
-        for upstream in upstream_jobs
-            is_unsatsifed_match_flag = Iterators.map(
-                (rel) -> rel[1] == upstream && !rel[3], 
-                dependency_relations
-                )
-            upstream_ready = !any(is_unsatsifed_match_flag)
-            if upstream_ready
-                results[upstream] = nothing
-            end
-        end
+    job_tree = JobTree(head_job)
+    @info "Collected $(length(get_node_lookup(job_tree))) jobs to complete."
+    root = get_root(job_tree)
+    schedule_job(root; ignore_target)
 
-        job_id = findfirst(p -> p[2] === nothing, (p for p in pairs(results)))
-        if job_id === nothing
-            completed_all_jobs = true
-        end
-    end
-    results[hash(head_job)]
+    get_result(root)
 end
 
 
-function get_dependency_details(head_job)
-    # The look up for the actual job objects
-    jobs = Dict{UInt64, AbstractJob}()
-    # Tracking if a job is ready to run
-    ready_jobs = Set{UInt64}()
-    dep_relations = Dict{Tuple{UInt64,UInt64,Bool}, Int}()
-    traverse_dependencies!(head_job, jobs, dep_relations, ready_jobs)
-    dep_relations = Set(keys(dep_relations))
-    return (jobs = jobs, dependency_relations = dep_relations, ready_jobs = ready_jobs)
-end
-
-function traverse_dependencies!(job, jobs, dep_relations, ready_jobs, depth = 1)
-    @debug "Maximum debug depth is 100. Currently at depth $depth"
-    job_id = hash(job)
-    if depth > 100
-        error("Reached maximum depth. It's possible that there is a cycle in the dependencies but the parameters are different each time.")
-    end
-    # We need to get the dependencies as a vector (get values of dicts)
-    dep_container = get_dependencies(job)
-    dep_list = get_dependencies_list(dep_container)
-
-    
-    # Jobs with no dependencies are ready to run
-    if isempty(dep_list)
-        push!(ready_jobs, job_id)
-    end
-
-    jobs[job_id] = job
-
-    # Go get grandchild dependency information
-    for dep in dep_list
-        dep_id = hash(dep)
-        dependency = (job_id, dep_id, false)
-        relation_occurances = get(dep_relations, dependency, 0) + 1
-        if relation_occurances > 25
-            check_for_circular_dependencies(jobs, keys(dep_relations))
-        end
-        dep_relations[(job_id, dep_id, false)] = relation_occurances
-        traverse_dependencies!(dep, jobs, dep_relations, ready_jobs, depth + 1)
-    end
-
-    return nothing
-end
-
-get_dependencies_list(deps::AbstractDict{Symbol, AbstractJob}) = collect(values(deps))
-get_dependencies_list(::Nothing) = AbstractJob[]
-get_dependencies_list(deps) = deps
-
-function check_for_circular_dependencies(jobs, dependency_relations)
-
-    # SimpleDiGraph only uses OneTo Ints as IDs so we need a map back to job ids
-    job_id_to_idx = Dict(
-        job_id => i
-        for (i, job_id) in enumerate(keys(jobs))
-    )
-
-    g = SimpleDiGraph(length(keys(jobs)))
-
-    for (job_id, dep_id, _) in dependency_relations
-        job_idx = job_id_to_idx[job_id]
-        dep_idx = job_id_to_idx[dep_id]
-        add_edge!(g, job_idx, dep_idx)
-    end
-
-    cycles = Graphs.simplecycles_iter(g)
-
-    # Build a clean looking printout for the dependency cycle error
-    if length(cycles) >= 1
-        cycle_explanation = Vector{String}(undef, length(cycles) + sum(length.(cycles)))
-        explain_idx = 1
-        for (i, cycle) in enumerate(cycles)
-            cycle_explanation[explain_idx] = "Cycle Number $i\n"
-            explain_idx += 1
-            for ci in eachindex(cycle)
-                job_idx = cycle[ci]
-                dep_idx = cycle[(ci)%length(cycle) + 1]
-                job_id = findfirst(p -> p[2]==job_idx, (p for p in pairs(job_id_to_idx)))[1]
-                dep_id = findfirst(p -> p[2]==dep_idx, (p for p in pairs(job_id_to_idx)))[1]
-                job = jobs[job_id]
-                dep = jobs[dep_id]
-                cycle_explanation[explain_idx] = "\tDependency Pair$ci\n\t\t$job\n\t\t$dep\n"
-                explain_idx += 1
-            end
-        end
-        throw(InvalidStateException("The dependency tree contains cycles. Please resolve.\n" * foldl(*, cycle_explanation), :CyclicalDependency))
-    end
-
-end
-
-
-id_to_name(hash_id) = Symbol("__$hash_id")
-
-
-function (job::AbstractJob)(job_id::UInt64, ignore_target, dependency_results...)
+function (@nospecialize(job::AbstractJob))(job_id::UInt64, ignore_target, @nospecialize(dependency_results...))
     @debug "Running spawned execution for job ID $job_id. Details: $job"
     target = get_target(job)
     
-    if iscomplete(target) && !ignore_target
+    if is_complete(target) && !ignore_target
         @debug "$job_id was already complete. Retrieving the target"
         data = retrieve(target)
         return ScheduledJob(job_id, target, data)

--- a/src/PipelineInternals.jl
+++ b/src/PipelineInternals.jl
@@ -1,0 +1,112 @@
+mutable struct JobNode{T} 
+    const id::UInt64
+    const parents::Vector{JobNode}
+    const job::T
+    complete::Bool
+    result::Union{Nothing, Dagger.EagerThunk}
+    const dependencies::Vector{JobNode}
+end
+
+get_id(n::JobNode) = n.id
+get_parents(n::JobNode) = n.parents
+function has_ancestor(n::JobNode, id)
+    for parent in get_parents(n)
+        if get_id(parent) == id || has_ancestor(parent, id)
+            return true
+        end
+    end
+    return false
+end
+
+get_job(n::JobNode) = n.job
+is_complete(n::JobNode) = n.complete
+get_result(n::JobNode) = n.result
+get_dependencies(n::JobNode) = [dep for dep in n.dependencies]
+is_ready(n::JobNode) = all(is_complete(dep) for dep in n.dependencies)
+is_required(n::JobNode) = n |> get_parents .|> !is_complete |> any
+
+
+struct JobTree
+    nodes::Dict{UInt64, JobNode}
+    root::JobNode
+end
+function JobTree(@nospecialize(job::AbstractJob))
+    nodes = Dict{UInt64, JobNode}()
+    root = add_job_node!(nodes, job)
+    return JobTree(nodes, root)
+end
+
+get_node_lookup(jt::JobTree) = jt.nodes
+get_root(jt::JobTree) = jt.root
+
+function add_job_node!(@nospecialize(nodes), @nospecialize(job::J), id::T = 0, parent = JobNode[]) where {T, J<:AbstractJob}
+    if !(T <: UInt64)
+        id = hash(job)
+    end
+    @debug "adding node for $(typeof(job))"
+
+    if id in keys(nodes)
+        @debug "this job was already processed"
+        node = nodes[id]
+        append!(node.parents, parent)
+        return node
+    end
+
+    complete = false
+    result = nothing
+    dependencies = get_dependencies(job)
+    dependency_nodes = Vector{JobNode}(undef, length(dependencies))
+    node = JobNode{J}(id, parent, job, complete, result, dependency_nodes)
+    nodes[id] = node
+
+    for (i,dep) in enumerate(dependencies)
+        @debug "adding dep of type $(typeof(job))"
+        dep_id = hash(dep)
+        if dep_id == id || has_ancestor(node, dep_id)
+            throw(InvalidStateException("The dependency tree contains cycles", :Cyclic))
+        end
+        @inbounds node.dependencies[i] = add_job_node!(nodes, dep, dep_id, [node])
+    end
+
+    return node 
+end
+
+function set_result!(@nospecialize(job_node::JobNode); ignore_target)
+    job_node.result = Dagger.@spawn (get_job(job_node))(
+        get_id(job_node), 
+        ignore_target, 
+        get_result.(get_dependencies(job_node))...
+    )
+    job_node.complete = true
+end
+
+function set_result!(@nospecialize(job_node::JobNode), data, complete = true)
+    job_node.result = data
+    job_node.complete = complete
+end
+
+
+
+function schedule_job(@nospecialize(job::JobNode); ignore_target)
+    if is_complete(job)
+        return nothing
+    end
+
+    dep_nodes = get_dependencies(job)
+    incomplete_deps = Iterators.filter(!is_complete, dep_nodes)
+
+    for dep in incomplete_deps
+        schedule_job(dep; ignore_target)
+    end
+
+    set_result!(job; ignore_target)
+
+    for dep in dep_nodes
+        if !is_required(dep)
+            set_result!(dep, nothing)
+        end
+    end
+
+    return nothing
+end
+

--- a/src/Target.jl
+++ b/src/Target.jl
@@ -18,7 +18,7 @@ return_type(::Type{<:AbstractTarget{T}}) where {T} = T
 struct NoTarget{T} <: AbstractTarget{T} end
 NoTarget() = NoTarget{Any}()
 Base.convert(::Type{AbstractTarget}, ::Nothing) = NoTarget{Any}()
-iscomplete(::NoTarget) = false
+is_complete(::NoTarget) = false
 
 """BinFileTarget(path)
 A target that serializes the result of a Job and stores it in a .bin file at the designated path.
@@ -30,7 +30,7 @@ struct BinFileTarget{T} <: AbstractTarget{T}
         return new{T}(path)
     end
 end
-iscomplete(t::BinFileTarget) = isfile(t.path)
+is_complete(t::BinFileTarget) = isfile(t.path)
 function store(t::BinFileTarget, data) 
     open(t.path, "w") do io
         serialize(io, data)

--- a/test/custom_target.jl
+++ b/test/custom_target.jl
@@ -8,7 +8,7 @@ struct ParquetDirTarget <: Waluigi.AbstractTarget{Parquet2.Dataset}
     read_kwargs
 end
 ParquetDirTarget(path; write_kwargs=(), read_kwargs=()) = ParquetDirTarget(path, write_kwargs, read_kwargs)
-Waluigi.iscomplete(t::ParquetDirTarget) = isdir(t.path)
+Waluigi.is_complete(t::ParquetDirTarget) = isdir(t.path)
 function Waluigi.store(t::ParquetDirTarget, data)
     isdir(t.path) && rm(t.path; force=true, recursive=true)
     mkdir(t.path)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,4 @@
+using Logging
 global_logger(ConsoleLogger(stderr, Logging.Error))
 
 using Scratch


### PR DESCRIPTION
Previously, I was using a bunch of dictionaries, sets, and graphs to track jobs, results, and dependencies. This PR replaces all of that with one, nice tree structure for faster querying of dependencies and dependees and tracking results and status alongside the job definition. 